### PR TITLE
parse hemisphere at beginning followed by space correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function(dmsString) {
 
     // Inspired by https://gist.github.com/JeffJacobson/2955437
     // See https://regex101.com/r/kS2zR1/3
-    var dmsRe = /([NSEW])?(-)?(\d+(?:\.\d+)?)[°º:d\s]?\s?(?:(\d+(?:\.\d+)?)['’‘′:]\s?(?:(\d{1,2}(?:\.\d+)?)(?:"|″|’’|'')?)?)?\s?([NSEW])?/i;
+    var dmsRe = /([NSEW])?\s?(-)?(\d+(?:\.\d+)?)[°º:d\s]?\s?(?:(\d+(?:\.\d+)?)['’‘′:]\s?(?:(\d{1,2}(?:\.\d+)?)(?:"|″|’’|'')?)?)?\s?([NSEW])?/i;
 
     var result = {};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-dms",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Parse degrees minutes seconds coordinates to decimal degrees",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-dms",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "description": "Parse degrees minutes seconds coordinates to decimal degrees",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,9 @@ test('Correctly parses DMS pairs with hemisphere at beginning', function(t) {
 
     var testData = [
         'N59°12\'7.7" W02°15\'39.6"',
+        'N 59°12\'7.7" W 02°15\'39.6"',
+        'N 59.20213888888889° W 2.261°',
+        'N 59.20213888888889 W 2.261',
         'W02°15\'39.6" N59°12\'7.7"'
     ];
 


### PR DESCRIPTION
Allow to parse not only `N59°12'7.7" W02°15'39.6"` but also `N 59°12'7.7" W 02°15'39.6"` which I often see in the wild.

Also bumps the Version Number to 0.0.4.