### PR TITLE
Add two test entries that failed in the current version, with a fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = function(dmsString) {
 
     // Inspired by https://gist.github.com/JeffJacobson/2955437
     // See https://regex101.com/r/kS2zR1/3
-    var dmsRe = /([NSEW])?(-)?(\d+(?:\.\d+)?)[°º:d\s]?\s?(?:(\d+(?:\.\d+)?)['’‘′:]\s?(?:(\d{1,2}(?:\.\d+)?)(?:"|″|’’|'')?)?)?\s?([NSEW])?/i;
+    var dmsRe = /([NSEW])?(-)?(\d+(?:\.\d+)?)[°º:d\s]?\s?(?:(\d+(?:\.\d+)?)['’‘′:]?\s?(?:(\d{1,2}(?:\.\d+)?)(?:"|″|’’|'')?)?)?\s?([NSEW])?/i;
 
     var result = {};
 

--- a/test/index.js
+++ b/test/index.js
@@ -162,7 +162,10 @@ test('Throws for seconds out of range', function(t) {
 test('Correctly parses DMS with decimal minutes', function(t) {
 
     var testData = [
-        'N59°12.105\' W02°15.66\''
+        'N59°12.105\' W02°15.66\'',
+        'N59:12.105\' W02:15.66\'',
+        'N59:12.105 W02:15.66',
+        '59:12.105\'N 02:15.66\'W'
     ];
 
     var expected = {


### PR DESCRIPTION
Entries with decimal minutes without seconds failed in case there was no explicit minutes sign (e.g. ' or `). An example is the string ```N59:12.105 W02:15.66```, which failed in the tests.

A question mark in the regex solves this. 